### PR TITLE
Add Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: perl6
+
+perl6:
+    - latest
+
+install:
+    - rakudobrew build-panda
+    - panda installdeps .


### PR DESCRIPTION
Assuming the patches in PR #4 (or a version thereof) are accepted, here is a Travis-CI configuration which would allow the test suite to be run automatically on the Travis infrastructure and should, theoretically, pass the tests.